### PR TITLE
Don't hardcode locales

### DIFF
--- a/functions_helper.py
+++ b/functions_helper.py
@@ -1,6 +1,6 @@
 import datetime, locale
 
-locale.setlocale(locale.LC_ALL, "german")
+locale.setlocale(locale.LC_ALL, '')
 
 date_format = '%Y/%m/%d'
 mensa_format = '%A, %d.%m.%Y'


### PR DESCRIPTION
Unless you have a very good reason to, do not hardcode locales.
If run on a different platform (operating system), there are a lot or chances that it might crash. It crashed on my linux machine.
The empty setlocale should pick up the default locale on the system.